### PR TITLE
Added #onJoin and #onExit Special Labels

### DIFF
--- a/ccs.cs
+++ b/ccs.cs
@@ -4284,6 +4284,15 @@ namespace PluginCCS {
                 "    If that script exists and has the label #accessControl, that label will be ran.",
                 "    If the package \"denyAccess\" is set to \"true\" when the script quits, then the player will be denied access to the map.",
                 "    It's important to note that this runs /before/ player joins the map, so it cannot act as a spawn MB that initializes temporary packages or whatnot, since joining a map resets packages.",
+                "",
+                "#onJoin",
+                "    This only works for staff scripts.",
+                "    Once the player joins a map this label will be run automatically.",
+                "",
+                "#onExit",
+                "    This only works for staff scripts.",
+                "    When the player leaves a map, this label will be run automatically.",
+                "    It will also run if the player disconnects from the server while on a map utilising it.",            
             };
 
             public override List<string> Body() {

--- a/ccs.cs
+++ b/ccs.cs
@@ -1663,7 +1663,7 @@ namespace PluginCCS {
         bool _cancelled;
         public bool cancelled {
             get { return _cancelled || startingLevelName != p.level.name.ToLower(); 
-                if (startLabel != "#onExit") { return _cancelled; }
+                if (p.Socket.Disconnected && startLabel != "#onExit") { return _cancelled; }
             }
             set {
                 if (value != true) { throw new System.ArgumentException("cancelled can only be set to true"); }

--- a/ccs.cs
+++ b/ccs.cs
@@ -4293,7 +4293,6 @@ namespace PluginCCS {
                 "    It's important to note that this runs /before/ player joins the map, so it cannot act as a spawn MB that initializes temporary packages or whatnot, since joining a map resets packages.",
                 "",
                 "#onJoin",
-                "    This only works for staff scripts.",
                 "    Once the player joins a map this label will be run automatically.",
                 "",
                 "#onExit",


### PR DESCRIPTION
### #onJoin
This label is automatically called upon the player joining a map. It can be useful for ensuring any "setup" script is run on every join. It has particular use over a message block at spawn for situations where a player has high ping which may lead to a missed activation.

### #onExit
This label is automatically called when the player leaves a map. It can be useful for applications where certain saved data needs to be modified if a player leaves, without the need for an awkward workaround.
It is also called if the player disconnects while on a map utilising it. 